### PR TITLE
Remove deprecated packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "fagc-backend",
 			"version": "2.0.0",
 			"hasInstallScript": true,
 			"license": "ISC",
@@ -38,8 +37,7 @@
 				"fastify-swagger": "^4.12.6",
 				"mongoose": "^6.0.14",
 				"mongoose-to-swagger": "^1.3.0",
-				"prom-client": "^14.0.1",
-				"tsc": "^2.0.3"
+				"prom-client": "^14.0.1"
 			},
 			"devDependencies": {
 				"@types/debug": "^4.1.7",
@@ -5297,14 +5295,6 @@
 			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
 			"integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
 		},
-		"node_modules/tsc": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/tsc/-/tsc-2.0.3.tgz",
-			"integrity": "sha512-SN+9zBUtrpUcOpaUO7GjkEHgWtf22c7FKbKCA4e858eEM7Qz86rRDpgOU2lBIDf0fLCsEg65ms899UMUIB2+Ow==",
-			"bin": {
-				"tsc": "bin/tsc"
-			}
-		},
 		"node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -9670,11 +9660,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
 			"integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
-		},
-		"tsc": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/tsc/-/tsc-2.0.3.tgz",
-			"integrity": "sha512-SN+9zBUtrpUcOpaUO7GjkEHgWtf22c7FKbKCA4e858eEM7Qz86rRDpgOU2lBIDf0fLCsEg65ms899UMUIB2+Ow=="
 		},
 		"tslib": {
 			"version": "1.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,9 +42,6 @@
 			"devDependencies": {
 				"@types/debug": "^4.1.7",
 				"@types/eslint": "^7.28.0",
-				"@types/fastify-rate-limit": "^2.1.0",
-				"@types/mongoose": "^5.11.97",
-				"@types/node-fetch": "^3.0.3",
 				"@types/nodemon": "^1.19.1",
 				"@types/prettier": "^2.4.1",
 				"@types/ws": "^7.4.6",
@@ -441,31 +438,11 @@
 			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
 			"dev": true
 		},
-		"node_modules/@types/fastify-rate-limit": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@types/fastify-rate-limit/-/fastify-rate-limit-2.1.0.tgz",
-			"integrity": "sha512-DWNoTWkKfbj+gQzJkKmNGRPnAueS9Q/JF3v2w67lMzsAdytA7uwrPXZY8OAAfhsVqRtelbIqVJBNGQPxAuiFOg==",
-			"deprecated": "This is a stub types definition. fastify-rate-limit provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"dependencies": {
-				"fastify-rate-limit": "*"
-			}
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
 			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
 			"dev": true
-		},
-		"node_modules/@types/mongoose": {
-			"version": "5.11.97",
-			"resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.11.97.tgz",
-			"integrity": "sha512-cqwOVYT3qXyLiGw7ueU2kX9noE8DPGRY6z8eUxudhXY8NZ7DMKYAxyZkLSevGfhCX3dO/AoX5/SO9lAzfjon0Q==",
-			"deprecated": "Mongoose publishes its own types, so you do not need to install this package.",
-			"dev": true,
-			"dependencies": {
-				"mongoose": "*"
-			}
 		},
 		"node_modules/@types/ms": {
 			"version": "0.7.31",
@@ -477,16 +454,6 @@
 			"version": "16.11.10",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
 			"integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA=="
-		},
-		"node_modules/@types/node-fetch": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz",
-			"integrity": "sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==",
-			"deprecated": "This is a stub types definition. node-fetch provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"dependencies": {
-				"node-fetch": "*"
-			}
 		},
 		"node_modules/@types/nodemon": {
 			"version": "1.19.1",
@@ -1587,15 +1554,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/data-uri-to-buffer": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-			"integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/debug": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -2589,28 +2547,6 @@
 			"integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
 			"dependencies": {
 				"reusify": "^1.0.4"
-			}
-		},
-		"node_modules/fetch-blob": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
-			"integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/jimmywarting"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/jimmywarting"
-				}
-			],
-			"dependencies": {
-				"web-streams-polyfill": "^3.0.3"
-			},
-			"engines": {
-				"node": "^12.20 || >= 14.13"
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -3905,23 +3841,6 @@
 			"integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
 			"dependencies": {
 				"semver": "^5.4.1"
-			}
-		},
-		"node_modules/node-fetch": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
-			"integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
-			"dev": true,
-			"dependencies": {
-				"data-uri-to-buffer": "^3.0.1",
-				"fetch-blob": "^3.1.2"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/node-fetch"
 			}
 		},
 		"node_modules/node-gyp-build": {
@@ -5490,15 +5409,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/web-streams-polyfill": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.0.tgz",
-			"integrity": "sha512-wO9r1YnYe7kFBLHyyVEhV1H8VRWoNiNnuP+v/HUUmSTaRF8F93Kmd3JMrETx0f11GXxRek6OcL2QtjFIdc5WYw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/webidl-conversions": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -6000,29 +5910,11 @@
 			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
 			"dev": true
 		},
-		"@types/fastify-rate-limit": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@types/fastify-rate-limit/-/fastify-rate-limit-2.1.0.tgz",
-			"integrity": "sha512-DWNoTWkKfbj+gQzJkKmNGRPnAueS9Q/JF3v2w67lMzsAdytA7uwrPXZY8OAAfhsVqRtelbIqVJBNGQPxAuiFOg==",
-			"dev": true,
-			"requires": {
-				"fastify-rate-limit": "*"
-			}
-		},
 		"@types/json-schema": {
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
 			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
 			"dev": true
-		},
-		"@types/mongoose": {
-			"version": "5.11.97",
-			"resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.11.97.tgz",
-			"integrity": "sha512-cqwOVYT3qXyLiGw7ueU2kX9noE8DPGRY6z8eUxudhXY8NZ7DMKYAxyZkLSevGfhCX3dO/AoX5/SO9lAzfjon0Q==",
-			"dev": true,
-			"requires": {
-				"mongoose": "*"
-			}
 		},
 		"@types/ms": {
 			"version": "0.7.31",
@@ -6034,15 +5926,6 @@
 			"version": "16.11.10",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
 			"integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA=="
-		},
-		"@types/node-fetch": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz",
-			"integrity": "sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==",
-			"dev": true,
-			"requires": {
-				"node-fetch": "*"
-			}
 		},
 		"@types/nodemon": {
 			"version": "1.19.1",
@@ -6830,12 +6713,6 @@
 					"integrity": "sha512-+UTPE7JT3O+sUpRroRgQAbbSfIRBwOHh+o/oruB1JJE6g6uBm3Y0D82fO3xu8VHfxJLQjeRp0PEY6mRmh/lElA=="
 				}
 			}
-		},
-		"data-uri-to-buffer": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-			"integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
-			"dev": true
 		},
 		"debug": {
 			"version": "4.3.3",
@@ -7626,15 +7503,6 @@
 			"integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
 			"requires": {
 				"reusify": "^1.0.4"
-			}
-		},
-		"fetch-blob": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
-			"integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
-			"dev": true,
-			"requires": {
-				"web-streams-polyfill": "^3.0.3"
 			}
 		},
 		"file-entry-cache": {
@@ -8616,16 +8484,6 @@
 			"integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
 			"requires": {
 				"semver": "^5.4.1"
-			}
-		},
-		"node-fetch": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
-			"integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
-			"dev": true,
-			"requires": {
-				"data-uri-to-buffer": "^3.0.1",
-				"fetch-blob": "^3.1.2"
 			}
 		},
 		"node-gyp-build": {
@@ -9816,12 +9674,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-		},
-		"web-streams-polyfill": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.0.tgz",
-			"integrity": "sha512-wO9r1YnYe7kFBLHyyVEhV1H8VRWoNiNnuP+v/HUUmSTaRF8F93Kmd3JMrETx0f11GXxRek6OcL2QtjFIdc5WYw==",
-			"dev": true
 		},
 		"webidl-conversions": {
 			"version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
 		"fastify-swagger": "^4.12.6",
 		"mongoose": "^6.0.14",
 		"mongoose-to-swagger": "^1.3.0",
-		"prom-client": "^14.0.1",
-		"tsc": "^2.0.3"
+		"prom-client": "^14.0.1"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -62,9 +62,6 @@
 	"devDependencies": {
 		"@types/debug": "^4.1.7",
 		"@types/eslint": "^7.28.0",
-		"@types/fastify-rate-limit": "^2.1.0",
-		"@types/mongoose": "^5.11.97",
-		"@types/node-fetch": "^3.0.3",
 		"@types/nodemon": "^1.19.1",
 		"@types/prettier": "^2.4.1",
 		"@types/ws": "^7.4.6",


### PR DESCRIPTION
The tsc dependency was a thirdparty build of nightly typescript that is deprecated and does nothing today. Likewise there are some typings packages that are deprecated stubs.