### PR TITLE
Fix setting API key, creation of initial community

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const start = async () => {
 		const port = typeof address === "string" ? address : address?.port
 		console.log(`Server listening on :${port}`)
 
-		client.login(ENV.DISCORD_BOTTOKEN)
+		await client.login(ENV.DISCORD_BOTTOKEN)
 
 		const communityCount = await CommunityModel.countDocuments()
 		if (communityCount == 0) {


### PR DESCRIPTION
- Fix setting of API key was required in the `roles` subset of the body
- Fix that the bot may not have been logged in by the point that the initial community was created, so the process waits for the bot to login first