### PR TITLE
Fix fetchAll issues

### DIFF
--- a/src/routes/reports.controller.ts
+++ b/src/routes/reports.controller.ts
@@ -57,7 +57,7 @@ export default class ReportController {
 			communityId: communityId,
 			categoryId: categoryId,
 			adminId: adminId,
-			...(after ? { createdAt: { $gt: new Date(after) } } : {}),
+			...(after ? { reportCreatedAt: { $gt: new Date(after) } } : {}),
 			revokedAt: { $exists: false },
 		})
 		return res.send(reports)

--- a/src/routes/revocations.controller.ts
+++ b/src/routes/revocations.controller.ts
@@ -24,9 +24,9 @@ export default class RevocationController {
 		options: {
 			schema: {
 				querystring: z.object({
-					playername: z.string().or(z.array(z.string())),
-					categoryId: z.string().or(z.array(z.string())),
-					adminId: z.string().or(z.array(z.string())),
+					playername: z.string().or(z.array(z.string())).optional(),
+					categoryId: z.string().or(z.array(z.string())).optional(),
+					adminId: z.string().or(z.array(z.string())).optional(),
 					after: z.string().optional().refine(
 						(input) => input === undefined || validator.isISO8601(input),
 						"Invalid timestamp"
@@ -74,7 +74,7 @@ export default class RevocationController {
 			playername: playername,
 			categoryId: categoryId,
 			adminId: adminId,
-			...(after ? { createdAt: { $gt: new Date(after) } } : {}),
+			...(after ? { reportCreatedAt: { $gt: new Date(after) } } : {}),
 			communityId: community.id,
 			revokedAt: {
 				$ne: null,


### PR DESCRIPTION
Fix fetchAll using the wrong field for querying reports by date, and the
revocations endpoint requiring parameters that should be optional.